### PR TITLE
Fix npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 src
-dist
+coffeelint.json
+.gitignore


### PR DESCRIPTION
The PR removes `dist` folder from _npmignore_. Currenlty, when retrieved _via_ npm/gh, the package doesn't contain the lib :disappointed: 
