### PR TITLE
fix package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 src
+lib
 coffeelint.json
 .gitignore

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "bugs": {
     "url": "https://github.com/cozy/cozysdk-client/issues"
   },
-  "main": "build/cozysdk-client.js",
+  "main": "dist/cozysdk-client.js",
   "scripts": {
     "build": "./node_modules/.bin/coffee -cb --output lib src && browserify lib/index.js --debug --s cozysdk | exorcist dist/cozysdk-client.js.map > dist/cozysdk-client.js ",
     "lint": "./node_modules/.bin/coffeelint src/* src/utils/*",


### PR DESCRIPTION
This PR fix the path in package.json `main` entry. It also excludes the temporary `lib` folder generated at compilation.
